### PR TITLE
Hoist proptypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ var connectTheme = exports.connectTheme = function connectTheme(mapThemeToCss) {
 
     wrapped.contextTypes = { theme: _react.PropTypes.object };
     wrapped.displayName = 'Theme(' + (Composed.displayName || 'component') + ')';
-
+    wrapped.propTypes = Composed.propTypes;
     return wrapped;
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes, Children } from 'react';
 import omit from 'lodash.omit';
-
 import useSheet from 'react-jss';
 
 // Provide the theme object to context
@@ -28,6 +27,6 @@ export const connectTheme = mapThemeToCss => Composed => {
 
   wrapped.contextTypes = { theme: PropTypes.object };
   wrapped.displayName = `Theme(${Composed.displayName || 'component'})`;
-
+  wrapped.propTypes = Composed.propTypes;
   return wrapped;
 };


### PR DESCRIPTION
Pretty self explanatory. Required to work with providers because it needs propTypes.
